### PR TITLE
Fixed momentum_density instantiations and test file

### DIFF
--- a/src/Evolution/Systems/ScalarWave/CMakeLists.txt
+++ b/src/Evolution/Systems/ScalarWave/CMakeLists.txt
@@ -11,6 +11,7 @@ spectre_target_sources(
   Characteristics.cpp
   Constraints.cpp
   EnergyDensity.cpp
+  MomentumDensity.cpp
   Equations.cpp
   TimeDerivative.cpp
   VolumeTermsInstantiation.cpp
@@ -23,6 +24,7 @@ spectre_target_headers(
   Characteristics.hpp
   Constraints.hpp
   EnergyDensity.hpp
+  MomentumDensity.hpp
   Equations.hpp
   Initialize.hpp
   System.hpp

--- a/src/Evolution/Systems/ScalarWave/MomentumDensity.cpp
+++ b/src/Evolution/Systems/ScalarWave/MomentumDensity.cpp
@@ -13,16 +13,17 @@
 namespace ScalarWave {
 template <size_t SpatialDim>
 void momentum_density(
-
     gsl::not_null<tnsr::i<DataVector, SpatialDim, Frame::Inertial>*> result,
     const Scalar<DataVector>& pi,
     const tnsr::i<DataVector, SpatialDim, Frame::Inertial>& phi) {
-  result = (pi * phi);
+  for (size_t i = 0; i < 3; i++) {
+    result->get(i) = pi * phi.get(i);
+  }
 }
 
 template <size_t SpatialDim>
 tnsr::i<DataVector, SpatialDim, Frame::Inertial> momentum_density(
-    const Scalar<DataVector>* pi,
+    const Scalar<DataVector>& pi,
     const tnsr::i<DataVector, SpatialDim, Frame::Inertial>& phi) {
   tnsr::i<DataVector, SpatialDim, Frame::Inertial> result{get(phi).size()};
   momentum_density(make_not_null(&result), pi, phi);
@@ -33,11 +34,11 @@ tnsr::i<DataVector, SpatialDim, Frame::Inertial> momentum_density(
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
-#define INSTANTIATE(_, data)
-template void ScalarWave::momentum_density(
-    gsl::not_null<tnsr::i<DataVector, SpatialDim, Frame::Inertial>*> result,
-    const Scalar<DataVector>& pi,
-    const tnsr::i<DataVector, DIM(data), Frame::Inertial>& phi);
+#define INSTANTIATE(_, data)                                                  \
+  template void ScalarWave::momentum_density(                                 \
+      gsl::not_null<tnsr::i<DataVector, DIM(data), Frame::Inertial>*> result, \
+      const Scalar<DataVector>& pi,                                           \
+      const tnsr::i<DataVector, DIM(data), Frame::Inertial>& phi);
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 

--- a/tests/Unit/Evolution/Systems/ScalarWave/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/ScalarWave/CMakeLists.txt
@@ -12,6 +12,7 @@ set(LIBRARY_SOURCES
   Test_Characteristics.cpp
   Test_Constraints.cpp
   Test_EnergyDensity.cpp
+  Test_MomentumDensity.cpp
   Test_Equations.cpp
   Test_TimeDerivative.cpp
   )

--- a/tests/Unit/Evolution/Systems/ScalarWave/Test_MomentumDensity.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarWave/Test_MomentumDensity.cpp
@@ -26,9 +26,8 @@ void test_compute_item_in_databox(const DataType& used_for_size) {
   MAKE_GENERATOR(generator);
   std::uniform_real_distribution<> dist(-1., 1.);
 
-  const tnsr::i<DataVector, SpatialDim, Frame::Inertial> pi =
-      make_with_random_values<tnsr::i<DataVector, SpatialDim, Frame::Inertial>>(
-          make_not_null(&generator), dist, used_for_size);
+  const Scalar<DataVector> pi = make_with_random_values<Scalar<DataVector>>(
+      make_not_null(&generator), dist, used_for_size);
   const tnsr::i<DataVector, SpatialDim, Frame::Inertial> phi =
       make_with_random_values<tnsr::i<DataVector, SpatialDim, Frame::Inertial>>(
           make_not_null(&generator), dist, used_for_size);
@@ -63,7 +62,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.ScalarWave.MomentumDensity",
       "Evolution/Systems/ScalarWave/");
 
   const DataVector used_for_size(5);
-  test_momentum_density(used_for_size);
+  test_momentum_density<1>(used_for_size);
   // test_momentum_density<2>(used_for_size);
   // test_momentum_density<3>(used_for_size);
 }


### PR DESCRIPTION
## Proposed changes

Fixes momentum density CMake libraries and test file and starts refining formula for momentum density calculation

### Upgrade instructions

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
