### PR TITLE
Fixed momentum density indexing and test file

### DIFF
--- a/src/Evolution/Systems/ScalarWave/MomentumDensity.cpp
+++ b/src/Evolution/Systems/ScalarWave/MomentumDensity.cpp
@@ -3,7 +3,6 @@
 
 #include "Evolution/Systems/ScalarWave/MomentumDensity.hpp"
 
-#include <iostream>
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
@@ -17,7 +16,7 @@ void momentum_density(
     gsl::not_null<tnsr::i<DataVector, SpatialDim, Frame::Inertial>*> result,
     const Scalar<DataVector>& pi,
     const tnsr::i<DataVector, SpatialDim, Frame::Inertial>& phi) {
-  for (size_t i = 0; i < 3; i++) {
+  for (size_t i = 0; i < SpatialDim; i++) {
     *result->get(i) = get(pi) * phi.get(i);
   }
 }

--- a/src/Evolution/Systems/ScalarWave/MomentumDensity.hpp
+++ b/src/Evolution/Systems/ScalarWave/MomentumDensity.hpp
@@ -21,12 +21,12 @@ class not_null;
 namespace ScalarWave {
 /// @{
 /*!
- * \brief Computes the momentum density of the scalar wave system.
+ * \brief Computes the energy density of the scalar wave system.
  *
- * Below is the function used to calculate the momentum density.
+ * Below is the function used to calculate the energy density.
  *
  * \f{align*}
- * \epsilon = \frac{1}{2}\left( \Pi^{2} + \abs{\Phi}^{2} \right)
+ * \epsilon = \Pi * \Phi_i
  * \f}
  */
 template <size_t SpatialDim>

--- a/tests/Unit/Evolution/Systems/ScalarWave/MomentumDensity.py
+++ b/tests/Unit/Evolution/Systems/ScalarWave/MomentumDensity.py
@@ -7,7 +7,7 @@ import numpy as np
 
 
 def momentum_density(pi, phi):
-    return np.linalg.norm(pi) * np.linalg.norm(phi)
+    return pi * phi
 
 
 #End functions for testing MomentumDensity.cpp

--- a/tests/Unit/Evolution/Systems/ScalarWave/Test_MomentumDensity.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarWave/Test_MomentumDensity.cpp
@@ -65,7 +65,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.ScalarWave.MomentumDensity",
       "Evolution/Systems/ScalarWave/");
 
   const DataVector used_for_size(5);
-  test_momentum_density<3>(used_for_size);
-  // test_momentum_density<2>(used_for_size);
-  // test_momentum_density<3>(used_for_size);
+   test_momentum_density<1>(used_for_size);
+   test_momentum_density<2>(used_for_size);
+   test_momentum_density<3>(used_for_size);
 }


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->
Fixes momentum density calculation indexing to not be hard-coded and fixes the test file to work for ScalarWave2D

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
